### PR TITLE
update default content pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,9 +6,7 @@ name: .NET
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,7 @@ name: .NET
 on:
   workflow_dispatch:
   push:
+    branches: main
   pull_request:
 
 jobs:

--- a/src/ContentPipeline/CodeBuilders/CSharpCodeBuilder.cs
+++ b/src/ContentPipeline/CodeBuilders/CSharpCodeBuilder.cs
@@ -14,7 +14,7 @@ public class CSharpCodeBuilder : IDisposable
 
         if (string.IsNullOrEmpty(start) is not true)
         {
-            if (start.Equals(Environment.NewLine, StringComparison.OrdinalIgnoreCase))
+            if (start.Equals(CodeConsts.NewLine, StringComparison.OrdinalIgnoreCase))
             {
                 CodeBuilder.AppendLine(Spaces);
             }
@@ -22,7 +22,6 @@ public class CSharpCodeBuilder : IDisposable
             {
                 CodeBuilder.AppendLine(Spaces + start);
             }
-
         }
 
     }
@@ -130,7 +129,7 @@ public static class CSharpCodeBuilderExtentions
 
     public static CSharpCodeBuilder<T> NewLine<T>(this CSharpCodeBuilder<T> builder)
     {
-        return new CSharpCodeBuilder<T>(builder.CodeBuilder, Environment.NewLine, indentation: builder.Indentation, parent: builder);
+        return new CSharpCodeBuilder<T>(builder.CodeBuilder, CodeConsts.NewLine, indentation: builder.Indentation, parent: builder);
     }
 
     public static CSharpCodeBuilder<T> Line<T>(this CSharpCodeBuilder<T> builder, string line = "", int indentation = 0)

--- a/src/ContentPipeline/CodeBuilders/CodeConsts.cs
+++ b/src/ContentPipeline/CodeBuilders/CodeConsts.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContentPipeline.CodeBuilders;
+internal static class CodeConsts
+{
+    internal const string NewLine = "\n";
+}

--- a/src/ContentPipeline/ContentPipeline.csproj
+++ b/src/ContentPipeline/ContentPipeline.csproj
@@ -10,6 +10,7 @@
 		<IsRoslynComponent>true</IsRoslynComponent>
 		<RootNamespace>ContentPipeline</RootNamespace>
 		<IsPackable>true</IsPackable>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	</PropertyGroup>
 	
 	<!-- NuGet properties -->

--- a/src/ContentPipeline/SourceGenerator/Emitter.Services.cs
+++ b/src/ContentPipeline/SourceGenerator/Emitter.Services.cs
@@ -65,7 +65,7 @@ internal partial class Emitter
                 .Class("public partial class ContentPipelineService : BaseContentPipelineService")
                 .Tab()
                 .NewLine()
-                .Line($"public ContentPipelineService({Environment.NewLine}\t\t\t{string.Join($", {Environment.NewLine}\t\t\t", contentClasses.Select(c => $"IContentPipeline<{c.FullyQualifiedName}, {GetPipelineModelFullName(c)}> {GetContentPipelineName(c)}"))})")
+                .Line($"public ContentPipelineService({CodeConsts.NewLine}\t\t\t{string.Join($", {CodeConsts.NewLine}\t\t\t", contentClasses.Select(c => $"IContentPipeline<{c.FullyQualifiedName}, {GetPipelineModelFullName(c)}> {GetContentPipelineName(c)}"))})")
                 .CodeBlock(block => block.Tab().Foreach(contentClasses,
                     (b, contentClass) =>
                     b.Line($"this.{GetContentPipelineName(contentClass)} = {GetContentPipelineName(contentClass)};")))
@@ -98,7 +98,7 @@ internal partial class Emitter
 
             internal class DefaultContentPipeline<TContent, TPipelineModel> : IContentPipeline<TContent, TPipelineModel> where TContent : IContentData where TPipelineModel : IContentPipelineModel, new()
             {
-                public DefaultContentPipeline(IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> contentPipelineSteps, IEnumerable<IContentPipelineStep<IContent, ContentPipelineModel>> sharedPipelineSteps)
+                public DefaultContentPipeline(IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> contentPipelineSteps, IEnumerable<IContentPipelineStep<IContentData, ContentPipelineModel>> sharedPipelineSteps)
                 {
                     ContentPipelineSteps = contentPipelineSteps.OrderBy(ps => ps.Order);
                     SharedPipelineSteps = sharedPipelineSteps.OrderBy(ps => ps.Order);
@@ -106,16 +106,16 @@ internal partial class Emitter
 
                 private IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> ContentPipelineSteps { get; }
 
-                private IEnumerable<IContentPipelineStep<IContent, ContentPipelineModel>> SharedPipelineSteps { get; }
+                private IEnumerable<IContentPipelineStep<IContentData, ContentPipelineModel>> SharedPipelineSteps { get; }
 
                 public TPipelineModel Run(TContent content, IContentPipelineContext pipelineContext)
                 {
                     TPipelineModel pipelineModel = new();
-                    if (content is IContent contentModel && pipelineModel is ContentPipelineModel sharedPipelineModel)
+                    if (pipelineModel is ContentPipelineModel sharedPipelineModel)
                     {
                         foreach (var sharedPipelineStep in SharedPipelineSteps)
                         {
-                            sharedPipelineStep.Execute(contentModel, sharedPipelineModel, pipelineContext);
+                            sharedPipelineStep.Execute(content, sharedPipelineModel, pipelineContext);
                         }
                     }
 


### PR DESCRIPTION
Updates the default content pipeline to use IContentData instead of IContent for the shared pipelines.
this is done in order to ensure default mapping support for ContentAreas that inlines blocks and thus will never be IContent 