### PR TITLE
Add Async Pipeline Step Support

### DIFF
--- a/src/ContentPipeline/SourceGenerator/Emitter.Interfaces.cs
+++ b/src/ContentPipeline/SourceGenerator/Emitter.Interfaces.cs
@@ -20,6 +20,7 @@ internal sealed partial class Emitter
         yield return new("IContentPipelinePropertyConverterAttribute.g.cs", CreateContentPipelinePropertyConverterAttributeInterface());
         yield return new("IContentPipelineContext.g.cs", CreatePipelineContextSource());
         yield return new("IContentPipelineStep.g.cs", CreatePipelineStep());
+        yield return new("AsyncContentPipelineStep.g.cs", CreateAsyncPipelineStep());
         yield return new("IContentPipelineService.g.cs", CreatePipelineService());
         yield return new("IContentPipeline.g.cs", CreateContentPipeline());
         yield return new("IContentPipelineModel.g.cs", CreateContentPipelineModel());
@@ -142,6 +143,51 @@ internal sealed partial class Emitter
                         Execute(content, contentPipelineModel, pipelineContext);
                         return Task.CompletedTask;
                     }
+                }
+                """;
+        }
+
+        string CreateAsyncPipelineStep()
+        {
+            return
+                $$"""
+                #nullable enable
+                namespace {{SharedNamespace}}.Pipelines;
+                
+                using EPiServer.Core;
+                using {{SharedNamespace}}.Interfaces;
+
+                public abstract class AsyncContentPipelineStep<TContent, TContentPipelineModel>(int order) :  {{SharedNamespace}}.Interfaces.IContentPipelineStep<TContent, TContentPipelineModel>
+                    where TContent : IContentData
+                    where TContentPipelineModel : {{SharedNamespace}}.Interfaces.IContentPipelineModel
+                {
+                    /// <summary>
+                    /// The order for the pipeline step, the sort order goes from low to high
+                    /// </summary>
+                    public int Order { get; } = order;
+
+                    /// <summary>
+                    /// A marker for whether the pipeline step is asynchronous
+                    /// True for AsyncContentPipelineSteps
+                    /// </summary>
+                    public bool IsAsync => true;
+                    
+                    /// <summary>
+                    /// Runs the pipeline step
+                    /// </summary>
+                    /// <param name="content"></param>
+                    /// <param name="contentPipelineModel"></param>
+                    /// <param name="pipelineContext"></param>
+                    public void Execute(TContent content, TContentPipelineModel contentPipelineModel, {{SharedNamespace}}.Interfaces.IContentPipelineContext pipelineContext) => throw new NotImplementedException();
+
+                    /// <summary>
+                    /// Runs the pipeline step asynchronously
+                    /// </summary>
+                    /// <param name="content"></param>
+                    /// <param name="contentPipelineModel"></param>
+                    /// <param name="pipelineContext"></param>
+                    /// <returns>A task</returns>
+                    public abstract Task ExecuteAsync(TContent content, TContentPipelineModel contentPipelineModel, ContentPipeline.Interfaces.IContentPipelineContext pipelineContext);
                 }
                 """;
         }

--- a/tests/ContentSourceGeneratorTests/SourceGeneratorTests/PipelineSteps/DefaultAsyncPipelineStep.cs
+++ b/tests/ContentSourceGeneratorTests/SourceGeneratorTests/PipelineSteps/DefaultAsyncPipelineStep.cs
@@ -1,0 +1,17 @@
+﻿using ContentPipeline.Interfaces;
+using ContentPipeline.Models.Awesome;
+using ContentPipelineSourceGeneratorTests.SourceGeneratorTests.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ContentPipelineSourceGeneratorTests.SourceGeneratorTests.PipelineSteps;
+internal class DefaultAsyncPipelineStep() : ContentPipeline.Pipelines.AsyncContentPipelineStep<ContentPage, ContentPagePipelineModel>(order: 100)
+{
+    public async override Task ExecuteAsync(ContentPage content, ContentPagePipelineModel contentPipelineModel, IContentPipelineContext pipelineContext)
+    {
+        await Task.Delay(10);
+    }
+}

--- a/tests/ContentSourceGeneratorTests/Tests/Pipelines/ContentPipeline_Given_Vaild_Content.cs
+++ b/tests/ContentSourceGeneratorTests/Tests/Pipelines/ContentPipeline_Given_Vaild_Content.cs
@@ -19,6 +19,7 @@ using NSubstitute;
 using System.Globalization;
 using System.Reflection;
 using ContentPipelineSourceGeneratorTests.SourceGeneratorTests.Attributes;
+using ContentPipelineSourceGeneratorTests.SourceGeneratorTests.PipelineSteps;
 
 namespace ContentPipelineSourceGeneratorTests.Tests.Pipelines;
 
@@ -50,6 +51,7 @@ public class ContentPipeline_Given_Vaild_Content
             .AddContentPipelineServices()
             .AddTransient<CustomConverter>()
             .AddTransient<DatasourceConverter>()
+            .AddTransient<IContentPipelineStep<ContentPage, ContentPipeline.Models.Awesome.ContentPagePipelineModel>, DefaultAsyncPipelineStep>()
             .AddTransient(sl => contentLoader)
             .AddTransient(sl => urlResolver)
             .AddTransient(sl => tempDataProvider)


### PR DESCRIPTION
#### PR Classification
New feature.

#### PR Summary
This pull request introduces asynchronous operations into the content pipeline framework, enhancing its flexibility and efficiency. 
- Added `AsyncContentPipelineStep<TContent, TContentPipelineModel>` abstract class in `Emitter.Interfaces.cs` to represent an asynchronous step in content pipelines.
- Implemented `DefaultAsyncPipelineStep` class in `DefaultAsyncPipelineStep.cs`, overriding `ExecuteAsync` for asynchronous operations.
- Registered `DefaultAsyncPipelineStep` in `ContentPipeline_Given_Vaild_Content.cs` for dependency injection, enabling its use in content pipeline processing.
