### PR TITLE
Add interface for executing post-content pipelines

### DIFF
--- a/src/ContentPipeline/SourceGenerator/Emitter.Interfaces.cs
+++ b/src/ContentPipeline/SourceGenerator/Emitter.Interfaces.cs
@@ -20,6 +20,7 @@ internal sealed partial class Emitter
         yield return new("IContentPipelinePropertyConverterAttribute.g.cs", CreateContentPipelinePropertyConverterAttributeInterface());
         yield return new("IContentPipelineContext.g.cs", CreatePipelineContextSource());
         yield return new("IContentPipelineStep.g.cs", CreatePipelineStep());
+        yield return new("IPostContentPipelineStep.g.cs", CreatePostPipelineStep());
         yield return new("AsyncContentPipelineStep.g.cs", CreateAsyncPipelineStep());
         yield return new("IContentPipelineService.g.cs", CreatePipelineService());
         yield return new("IContentPipeline.g.cs", CreateContentPipeline());
@@ -145,6 +146,53 @@ internal sealed partial class Emitter
                     }
                 }
                 """;
+        }
+
+        string CreatePostPipelineStep()
+        {
+            return
+                $$"""
+                  #nullable enable
+                  namespace {{SharedNamespace}}.Interfaces;
+
+                  using EPiServer.Core;
+
+                  public partial interface IPostContentPipelineStep<in TContent, in TContentPipelineModel>
+                      where TContent : IContentData
+                      where TContentPipelineModel : {{SharedNamespace}}.Interfaces.IContentPipelineModel
+                  {
+                      /// <summary>
+                      /// The order for the pipeline step, the sort order goes from low to high
+                      /// </summary>
+                      int Order { get; }
+                  
+                      /// <summary>
+                      /// A marker for whether the pipeline step is asynchronous
+                      /// </summary>
+                      bool IsAsync => false;
+                      
+                      /// <summary>
+                      /// Runs the pipeline step
+                      /// </summary>
+                      /// <param name="content"></param>
+                      /// <param name="contentPipelineModel"></param>
+                      /// <param name="pipelineContext"></param>
+                      void Execute(TContent content, TContentPipelineModel contentPipelineModel, {{SharedNamespace}}.Interfaces.IContentPipelineContext pipelineContext);
+                  
+                      /// <summary>
+                      /// Runs the pipeline step asynchronously
+                      /// </summary>
+                      /// <param name="content"></param>
+                      /// <param name="contentPipelineModel"></param>
+                      /// <param name="pipelineContext"></param>
+                      /// <returns>A task</returns>
+                      Task ExecuteAsync(TContent content, TContentPipelineModel contentPipelineModel, ContentPipeline.Interfaces.IContentPipelineContext pipelineContext)
+                      {
+                          Execute(content, contentPipelineModel, pipelineContext);
+                          return Task.CompletedTask;
+                      }
+                  }
+                  """;
         }
 
         string CreateAsyncPipelineStep()

--- a/src/ContentPipeline/SourceGenerator/Emitter.Services.cs
+++ b/src/ContentPipeline/SourceGenerator/Emitter.Services.cs
@@ -116,15 +116,18 @@ internal partial class Emitter
 
             internal class DefaultContentPipeline<TContent, TPipelineModel> : IContentPipeline<TContent, TPipelineModel> where TContent : IContentData where TPipelineModel : IContentPipelineModel, new()
             {
-                public DefaultContentPipeline(IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> contentPipelineSteps, IEnumerable<IContentPipelineStep<IContentData, ContentPipelineModel>> sharedPipelineSteps)
+                public DefaultContentPipeline(IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> contentPipelineSteps, IEnumerable<IContentPipelineStep<IContentData, ContentPipelineModel>> sharedPipelineSteps, IEnumerable<IPostContentPipelineStep<IContentData, ContentPipelineModel>> postContentPipelineSteps)
                 {
                     ContentPipelineSteps = contentPipelineSteps.OrderBy(ps => ps.Order);
                     SharedPipelineSteps = sharedPipelineSteps.OrderBy(ps => ps.Order);
+                    PostContentPipelineSteps = postContentPipelineSteps.OrderBy(ps => ps.Order);
                 }
 
                 private IEnumerable<IContentPipelineStep<TContent, TPipelineModel>> ContentPipelineSteps { get; }
 
                 private IEnumerable<IContentPipelineStep<IContentData, ContentPipelineModel>> SharedPipelineSteps { get; }
+                
+                private IEnumerable<IPostContentPipelineStep<IContentData, ContentPipelineModel>> PostContentPipelineSteps { get; }
 
                 public TPipelineModel Run(TContent content, IContentPipelineContext pipelineContext)
                 {
@@ -140,6 +143,14 @@ internal partial class Emitter
                     foreach (var step in ContentPipelineSteps)
                     {
                         step.Execute(content, pipelineModel, pipelineContext);
+                    }
+                    
+                    if (pipelineModel is ContentPipelineModel postPipelineModel)
+                    {
+                        foreach (var step in PostContentPipelineSteps)
+                        {
+                            step.Execute(content, postPipelineModel, pipelineContext);
+                        }
                     }
 
                     return pipelineModel;


### PR DESCRIPTION
Adds the following features

- New interface `IPostContentPipeline` which executes after `Shared` and `Content` pipelines for post-processing needs
- Extends `DefaultPipelineService` to execute `IPostContentPipeline` services